### PR TITLE
Better support for smaller chips, and a bugfix when converting float->str

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ examples from `examples/` folder.
 - Bug fix. Peripheral odma could enter a dead state if a block larger than the
   ODMA buffer size was written.
 - Bug fix, #20. Implemented set_databits for DMA based UART.
+- Support for building on targets with only 1 SPI bus, such as the UC3C2512C.
+- Bug fix. Converting float or double values between -1.0 < x < -0.0 to a
+  string always resulted in a positive value in the string.
 
 ### v0.6.3
 

--- a/aery32/aery32/spi.h
+++ b/aery32/aery32/spi.h
@@ -36,10 +36,12 @@ namespace aery {
  */
 extern volatile avr32_spi_t *spi0;
 
+#if AVR32_NUM_SPI > 1
 /**
  * Pointer to the internal Serial peripheral interdace module register 1
  */
 extern volatile avr32_spi_t *spi1;
+#endif
 
 /**
  * SPI mode

--- a/aery32/spi.cpp
+++ b/aery32/spi.cpp
@@ -20,8 +20,17 @@
 
 namespace aery {
 	volatile avr32_spi_t *spi0 = &AVR32_SPI0;
+#if AVR32_NUM_SPI > 1
 	volatile avr32_spi_t *spi1 = &AVR32_SPI1;
-	volatile uint32_t __spi_lsr[2] = { AVR32_SPI0.sr, AVR32_SPI1.sr };
+#endif
+
+	volatile uint32_t __spi_lsr[] =
+   {
+      AVR32_SPI0.sr,
+#if AVR32_NUM_SPI > 1
+      AVR32_SPI1.sr
+#endif
+   };
 }
 
 static uint8_t pspi2num(volatile avr32_spi_t *pspi)

--- a/aery32/string.cpp
+++ b/aery32/string.cpp
@@ -1,7 +1,7 @@
 /*
  *  _____             ___ ___   |
  * |  _  |___ ___ _ _|_  |_  |  |  C/C++ framework for 32-bit AVRs
- * |     | -_|  _| | |_  |  _|  |  
+ * |     | -_|  _| | |_  |  _|  |
  * |__|__|___|_| |_  |___|___|  |  https://github.com/aery32
  *               |___|          |
  *
@@ -26,7 +26,7 @@ char *aery::utoa(unsigned int number, char *buffer, size_t *n)
 {
 	uint8_t i = 0, k = 0;
 	char t;
-	
+
 	if (number == 0)
 		buffer[i++] = '0';
 
@@ -72,11 +72,20 @@ char *aery::dtoa(double number, uint8_t precision, char *buffer, size_t *n)
 		if (n != NULL) *n = 3;
 		return strcpy(buffer, "Inf");
 	}
-	if ((fp = modf(number, &ip)) < 0)
+
+	fp = modf(number, &ip);
+	if (std::signbit(number)) {
+		/* compensate for loss of sign when converting -0.0 to integer */
 		fp *= -1;
+		ip *= -1;
+		buffer[0] = '-';
+		++n2;
+	}
 
 	/* write the integer part and the dot into the buffer */
-	aery::itoa((int) ip, buffer, &n2);
+	aery::utoa((unsigned int) ip, &buffer[n2], &n2);
+	if (std::signbit(number))
+		++n2;
 	buffer[n2++] = '.';
 
 	/* write the fractional part into the buffer */
@@ -104,15 +113,15 @@ int aery::nputs(const char *buffer, size_t n, int (*_putchar)(int))
 int aery::line_to_argv(char *line, char *argv[])
 {
 	unsigned int i = 0, j = 0;
- 
+
 	begin:
 		while (line[i] && isspace(line[i])) i++;
 		argv[j++] = &line[i];
- 
- 		while (line[i] && !isspace(line[i])) i++;
+
+		while (line[i] && !isspace(line[i])) i++;
 		if (line[i] == '\0') goto end;
 		line[i++] = '\0'; goto begin;
- 
+
 	end:
 		return j;
 }


### PR DESCRIPTION
This one makes it possible to compile spi.cpp on targets which have fewer SPI busses than the original chip. For example, UC3C2512C only has one SPI port.

There was also a bug in the float/double to string conversion on numbers between -0.0 and -0.999999. After the value was split into its integral- and fractional components the integral component was converted to an integer and written as text to the buffer. When the integral part was -0.0 the sign was discarded. I found no clean way of dealing with this as -0 doesn't seem to exist on integers as far as I could see.

Sorry for the tab/spaces mess. I tried my best to keep it to tabs only.