### PR TITLE
Fix use of incorrect define when checking the number of available SPI…

### DIFF
--- a/aery32/aery32/spi.h
+++ b/aery32/aery32/spi.h
@@ -36,7 +36,7 @@ namespace aery {
  */
 extern volatile avr32_spi_t *spi0;
 
-#if AVR32_NUM_SPI > 1
+#if AVR32_SPI_NUM > 1
 /**
  * Pointer to the internal Serial peripheral interdace module register 1
  */

--- a/aery32/spi.cpp
+++ b/aery32/spi.cpp
@@ -20,14 +20,14 @@
 
 namespace aery {
 	volatile avr32_spi_t *spi0 = &AVR32_SPI0;
-#if AVR32_NUM_SPI > 1
+#if AVR32_SPI_NUM > 1
 	volatile avr32_spi_t *spi1 = &AVR32_SPI1;
 #endif
 
 	volatile uint32_t __spi_lsr[] =
    {
       AVR32_SPI0.sr,
-#if AVR32_NUM_SPI > 1
+#if AVR32_SPI_NUM > 1
       AVR32_SPI1.sr
 #endif
    };


### PR DESCRIPTION
The example should compile now. I assumed that they compiled when doing a regular make, sorry about that.
